### PR TITLE
added install_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup(
     name='scheduler',
     version='0.1.0',
     packages=['scheduler'],
+    install_requires=[
+    	'gspread',
+    	'oauth2client',
+    ],
     include_package_data=True,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Automatically installs oauth2client and gspread if not already installed. Does not specify minimum version requirements.