### PR TITLE
Switch to exact time matching, remove matching by delta time

### DIFF
--- a/scheduler/generate_rides.py
+++ b/scheduler/generate_rides.py
@@ -119,7 +119,7 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
 
     driver_time = driver_times[0]
 
-    result = -1
+    result = float(-1)
 
     # finds earliest matching time, rider times are sorted
     for time in rider_times:

--- a/scheduler/generate_rides.py
+++ b/scheduler/generate_rides.py
@@ -102,6 +102,7 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
 
     Returns:
         Float of the earliest matching departure time in the rider and driver
+        or -1 if no match was found
     """
 
     rider_times = rider.get_times(day)

--- a/scheduler/generate_rides.py
+++ b/scheduler/generate_rides.py
@@ -106,7 +106,8 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
 
     rider_times.sort()
 
-    # there should only be one time here
+    # there should only be one time here, so maybe remove
+    # maybe keep this in case there are more than 1 to keep things deterministic
     driver_times.sort()
 
     if len(driver_times) != 1:
@@ -115,14 +116,17 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
 
     driver_time = driver_times[0]
 
+    #
     result = sys.maxsize
 
-    # finds minimum difference between rider departure times and driver time
+    # finds earliest matching time, rider times are sorted
     for time in rider_times:
-        if abs(time - driver_time) < result:
-            result = abs(time - driver_time)
+        if time == driver_time:
+            logger.debug("rider %s time compatible with %s", rider.name,
+                         driver.name)
+            result = time
+            break
 
-    logger.debug("min time difference: %i", result)
     return result
 
 
@@ -152,8 +156,8 @@ def find_best_match(rider: Rider, drivers: list,
     """
 
     # this probably needs to be rewritten with some kind of proper algorithm.
-    # right now, we're choosing the driver that is leaving closest to the requested time
-    # given day and location compatibility.
+    # right now, we're choosing the driver that matches the earliest of the
+    # rider's desired times
     #
     # this algorithm is a good choice if we truly want to give everyone an ~equal~ chance
     # in getting a car but we disregard how well they fit in it relative to others.
@@ -176,7 +180,7 @@ def find_best_match(rider: Rider, drivers: list,
     # [0] -> Driver object
     # [1] -> float that is the timne delta between when this specific driver and a rider want to leave
 
-    # Sort the compatible drivers list based on the time delta between drivers and riders
+    # Sort the compatible drivers list to find the compatible driver leaving earliest
     # Store the smallest driver dictionary value into the best match variable
     best_match = sorted(compatible_drivers, key=lambda lst: lst[1])[0][0]
 

--- a/scheduler/generate_rides.py
+++ b/scheduler/generate_rides.py
@@ -97,8 +97,7 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
             Day.DayName enum of day for which to check time compatability
 
     Returns:
-        Float that is the minimum time difference between when a specific driver and rider would
-        like to leave
+        Float of the earliest matching departure time in the rider and driver
     """
 
     rider_times = rider.get_times(day)
@@ -116,8 +115,7 @@ def time_compatibility(rider: Rider, driver: Driver, day: Day.DayName) -> float:
 
     driver_time = driver_times[0]
 
-    #
-    result = sys.maxsize
+    result = -1
 
     # finds earliest matching time, rider times are sorted
     for time in rider_times:
@@ -168,8 +166,11 @@ def find_best_match(rider: Rider, drivers: list,
     for driver in drivers:
         if driver.seats_remaining and are_location_compatible(
                 rider, driver, day):
-            compatible_drivers.append(
-                [driver, time_compatibility(rider, driver, day)])
+            departure_time = time_compatibility(rider, driver, day)
+
+            # departure time will be -1 if rider and driver are not time compatible
+            if departure_time > 0:
+                compatible_drivers.append([driver, departure_time])
 
     if not compatible_drivers:
         logger.warn("no compatible drivers for %s", rider.name)

--- a/scheduler/gform_backend.py
+++ b/scheduler/gform_backend.py
@@ -174,12 +174,12 @@ def get_days_and_locations(start_col: int, response: int,
 
             times_strs = response[i + len(days_enabled)].split(",")
 
-            day = Day.DayInfo(
-                day=Day.from_str(d),
-                times=[
-                    parse_times(times_strs[i]) for  i in range(0, len(times_strs))
-                ],
-                locations=list())
+            day = Day.DayInfo(day=Day.from_str(d),
+                              times=[
+                                  parse_times(times_strs[i])
+                                  for i in range(0, len(times_strs))
+                              ],
+                              locations=list())
 
             locations = response[i].split(",")
 

--- a/scheduler/gform_backend.py
+++ b/scheduler/gform_backend.py
@@ -171,10 +171,13 @@ def get_days_and_locations(start_col: int, response: int,
 
         # if driving this day
         if response[i]:
+
+            times_strs = response[i + len(days_enabled)].split(",")
+
             day = Day.DayInfo(
                 day=Day.from_str(d),
                 times=[
-                    parse_times(response[i + len(days_enabled)].split(",")[0])
+                    parse_times(times_strs[i]) for  i in range(0, len(times_strs))
                 ],
                 locations=list())
 
@@ -239,7 +242,7 @@ def get_riders_and_drivers(
                             seats=int(row[seats_column]))
 
             for d in driver.days:
-                logger.debug("%s: %s", driver.name, d)
+                logger.debug("[Driver] %s: %s", driver.name, d)
 
             drivers.append(driver)
 
@@ -252,6 +255,9 @@ def get_riders_and_drivers(
                               row[email_column], dues_payers),
                           days=get_days_and_locations(days_info_start_column,
                                                       row, days_enabled))
+
+            for d in rider.days:
+                logger.debug("[Rider] %s: %s", rider.name, d)
 
             riders.append(rider)
 

--- a/scheduler/tests/test_data.py
+++ b/scheduler/tests/test_data.py
@@ -177,7 +177,7 @@ class GenerateRidesTestData:
                 }]
             },
             "MONDAY",
-            0,
+            4,
         ),
         (
             {
@@ -193,7 +193,7 @@ class GenerateRidesTestData:
                 }]
             },
             "TUESDAY",
-            4,
+            -1,
         ),
         (
             {
@@ -209,7 +209,7 @@ class GenerateRidesTestData:
                 }]
             },
             "MONDAY",
-            1.5,
+            -1,
         ),
     ]
 
@@ -219,7 +219,7 @@ class GenerateRidesTestData:
                 "name":
                     "r",
                 "days": [{
-                    "day": "MONDAY",
+                    "day": "TUESDAY",
                     "locations": ["NORTH"],
                     "departure_times": [1, 2, 3],
                 }],
@@ -273,13 +273,13 @@ class GenerateRidesTestData:
                         4,
                     "days": [{
                         "day": "TUESDAY",
-                        "locations": ["CENTRAL"],
+                        "locations": ["NORTH"],
                         "departure_times": [2],
                     }],
                 },
             ],
-            "MONDAY",
-            "a",
+            "TUESDAY",
+            "d",
         ),
     ]
 


### PR DESCRIPTION
Wait to merge until #45 is merged. #45 may change matching process behavior.

Match riders with drivers using exact times instead of deltas. If a driver matches any of the rider's times exactly, the driver is considered compatible. The best driver is the driver leaving the earliest. We may need to discuss defining best as earliest departing. Currently, the reasoning is an earlier departure usually leads to more climbing time.

Close #31 

