### PR TITLE
Add sphinx documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,12 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
 import sphinx_rtd_theme
+
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(1, os.path.abspath('./classes'))
 
 # -- Project information -----------------------------------------------------
 
@@ -26,7 +28,7 @@ author = 'Nathan Silverman, Roberts Kalnins'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_rtd_theme"]
+extensions = ['sphinx_rtd_theme', 'sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,54 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+import sphinx_rtd_theme
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Michigan Climbing Club Carpool Scheduler'
+copyright = '2020, Nathan Silverman, Roberts Kalnins'
+author = 'Nathan Silverman, Roberts Kalnins'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx_rtd_theme"
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,22 +15,18 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import sphinx_rtd_theme
 
-
 # -- Project information -----------------------------------------------------
 
 project = 'Michigan Climbing Club Carpool Scheduler'
 copyright = '2020, Nathan Silverman, Roberts Kalnins'
 author = 'Nathan Silverman, Roberts Kalnins'
 
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    "sphinx_rtd_theme"
-]
+extensions = ["sphinx_rtd_theme"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -39,7 +35,6 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,9 +6,18 @@
 Welcome to Michigan Climbing Club Carpool Scheduler's documentation!
 ====================================================================
 
+The carpool scheduling software is designed to fairly match drivers and riders going to Planet Rock (a local climbing gym in Ann Arbor) with carpools that match both the driver and riders unique date, time, and location preferences. 
+
+The software relies on data collection from drivers and riders to happen through a google form. The responses collected in the google form are stored in a google sheet. The program is then able to read these responses, and fairly match drivers and riders. Once results are calculated, the program will publish its results to a google sheet. The program is designed to give carpool seat priority to due paying club members seeking a ride, while also ensuring that all due paying members have an equal chance at getting a ride. 
+ 
+This software was designed to solve issues within the Michigan Climbing Club related to fairness and due paying member priority when members tried to get rides to Planet Rock in years past.  Version 1.0.0 of the software has succesfully worked for over a year. Version 2.0.0 is currently under development.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+
+   usage
+   source/modules
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+.. Michigan Climbing Club Carpool Scheduler documentation master file, created by
+   sphinx-quickstart on Sat Jul 18 18:11:17 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Michigan Climbing Club Carpool Scheduler's documentation!
+====================================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/AuthorizedClient.rst
+++ b/docs/source/AuthorizedClient.rst
@@ -1,0 +1,7 @@
+AuthorizedClient
+=======================
+
+.. automodule:: scheduler.classes.AuthorizedClient
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Car.rst
+++ b/docs/source/Car.rst
@@ -1,0 +1,7 @@
+Car
+==========
+
+.. automodule:: scheduler.classes.Car
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Configuration.rst
+++ b/docs/source/Configuration.rst
@@ -1,0 +1,7 @@
+Configuration
+====================
+
+.. automodule:: scheduler.classes.Configuration
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Day.rst
+++ b/docs/source/Day.rst
@@ -1,0 +1,7 @@
+Day
+==========
+
+.. automodule:: scheduler.classes.Day
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Driver.rst
+++ b/docs/source/Driver.rst
@@ -1,0 +1,7 @@
+Driver
+=============
+
+.. automodule:: scheduler.classes.Driver
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/MeetingLocation.rst
+++ b/docs/source/MeetingLocation.rst
@@ -1,0 +1,7 @@
+MeetingLocation
+======================
+
+.. automodule:: scheduler.classes.MeetingLocation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Member.rst
+++ b/docs/source/Member.rst
@@ -1,0 +1,7 @@
+Member
+=============
+
+.. automodule:: scheduler.classes.Member
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/Rider.rst
+++ b/docs/source/Rider.rst
@@ -1,0 +1,7 @@
+Rider
+============
+
+.. automodule:: scheduler.classes.Rider
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/WSCell.rst
+++ b/docs/source/WSCell.rst
@@ -1,0 +1,7 @@
+WSCell
+=============
+
+.. automodule:: scheduler.classes.WSCell
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/WSRange.rst
+++ b/docs/source/WSRange.rst
@@ -1,0 +1,7 @@
+WSRange
+==============
+
+.. automodule:: scheduler.classes.WSRange
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -1,0 +1,16 @@
+classes
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   AuthorizedClient
+   Car
+   Configuration
+   Day
+   Driver
+   MeetingLocation
+   Member
+   Rider
+   WSCell
+   WSRange

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,8 @@
+scheduler
+=========
+
+.. toctree::
+   :maxdepth: 4
+
+   scheduler
+   scheduler.classes <classes.rst>

--- a/docs/source/scheduler.rst
+++ b/docs/source/scheduler.rst
@@ -1,0 +1,38 @@
+scheduler package
+=================
+
+Submodules
+----------
+
+scheduler.generate\_rides module
+--------------------------------
+
+.. automodule:: scheduler.generate_rides
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+scheduler.gform\_backend module
+-------------------------------
+
+.. automodule:: scheduler.gform_backend
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+scheduler.util module
+---------------------
+
+.. automodule:: scheduler.util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: scheduler
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,10 @@
+Usage
+=========
+
+Usage is simple and options are provided::
+
+   $ scheduler
+
+This will list the available options that can be used to run the program.
+
+Running the program requires a secrets.json file that is the key to a service account for the google developer console project. This is needed to allow the program to communicate with google drive. To get this setup, access needs to be granted by a system admin. Contact Nathan Silverman or Roberts Kalnins for this. 

--- a/scheduler/gform_backend.py
+++ b/scheduler/gform_backend.py
@@ -135,19 +135,18 @@ def get_days_and_locations(start_col: int, response: int,
 
     #  TODO: this documentation does not play nice with autdoc, find another way to include this somewhere
     #  assume each day has a locations column and a departure times column
-    
-    #  n = days_enabled
 
+    #  n = days_enabled
 
     #  This diagram is a representation of the Google Form responses sheet showing from which
     #  columns data is being extracted. Day 1 Locations Rider is the first column of
-    #  location data if the member is a rider (column I of the current v2.0.0 responses sheet). 
+    #  location data if the member is a rider (column I of the current v2.0.0 responses sheet).
 
     #              (start rider iter here)  (end rider iter here)  (start driver iter here)                 (end driver iter here)
     #              DAYS_INFO_START                            |    driver_days_start                            |
     #                 |                                       |         |                                       |
     #                 V                                       V         V                                       V
-    #          |   | Day 1     |   | Day n     | Day 1 |   | Day n | Day 1     |   | Day n     | Day 1  |   | Day n  | 
+    #          |   | Day 1     |   | Day n     | Day 1 |   | Day n | Day 1     |   | Day n     | Day 1  |   | Day n  |
     #          |   | Locations |...| Locations | Times |...| Times | Locations |...| Locations | Times  |...| Times  |
     #          |   | Rider     |   | Rider     | Rider |   | Rider | Driver    |   | Driver    | Driver |   | Driver |
     #  --------|...|-----------|---|-----------|-------|---|-------|-----------|---|-----------|--------|---|--------|

--- a/scheduler/gform_backend.py
+++ b/scheduler/gform_backend.py
@@ -118,45 +118,45 @@ def get_days_and_locations(start_col: int, response: int,
             days_enabled:
                 a list of days for which the scheduler is scheduling
 
-        Returns
+        Returns:
             a list of DayInfo objects corresponding to the provided carpool form response
     
-
-        Typical Usage:
-            rider = Rider(
-                name=row[name_column],
-                email=row[email_column],
-                phone=row[phone_column],
-                is_dues_paying=validate_dues_payers(row[email_column],
-                                                    dues_payers),
-                days=get_days_and_locations(days_info_start_column, row,
-                                            days_enabled))
-
-
-     assume each day has a locations column and a departure times column
-    
-     n = days_enabled
-
-
-     This diagram is a representation of the Google Form responses sheet showing from which
-     columns data is being extracted. Day 1 Locations Rider is the first column of
-     location data if the member is a rider (column I of the current v2.0.0 responses sheet). 
-
-                 (start rider iter here)  (end rider iter here)  (start driver iter here)                 (end driver iter here)
-                 DAYS_INFO_START                            |    driver_days_start                            |
-                    |                                       |         |                                       |
-                    V                                       V         V                                       V
-             |   | Day 1     |   | Day n     | Day 1 |   | Day n | Day 1     |   | Day n     | Day 1  |   | Day n  | 
-             |   | Locations |...| Locations | Times |...| Times | Locations |...| Locations | Times  |...| Times  |
-             |   | Rider     |   | Rider     | Rider |   | Rider | Driver    |   | Driver    | Driver |   | Driver |
-     --------|...|-----------|---|-----------|-------|---|-------|-----------|---|-----------|--------|---|--------|
-     Member 1|   |           |   |           |       |   |       |           |   |           |        |   |        |
-     Member 2|   |
-     .       |   |
-     .       |   |
-     .       |   |
-     Member n|   |
     """
+    #   TODO: see comment below, include this in docstring. Fix this as well:
+    #         Typical Usage:
+    #               rider = Rider(
+    #                   name=row[name_column],
+    #                   email=row[email_column],
+    #                   phone=row[phone_column],
+    #                   is_dues_paying=validate_dues_payers(row[email_column],
+    #                                     dues_payers),
+    #                   days=get_days_and_locations(days_info_start_column, row,
+    #                             days_enabled))
+
+    #  TODO: this documentation does not play nice with autdoc, find another way to include this somewhere
+    #  assume each day has a locations column and a departure times column
+    
+    #  n = days_enabled
+
+
+    #  This diagram is a representation of the Google Form responses sheet showing from which
+    #  columns data is being extracted. Day 1 Locations Rider is the first column of
+    #  location data if the member is a rider (column I of the current v2.0.0 responses sheet). 
+
+    #              (start rider iter here)  (end rider iter here)  (start driver iter here)                 (end driver iter here)
+    #              DAYS_INFO_START                            |    driver_days_start                            |
+    #                 |                                       |         |                                       |
+    #                 V                                       V         V                                       V
+    #          |   | Day 1     |   | Day n     | Day 1 |   | Day n | Day 1     |   | Day n     | Day 1  |   | Day n  | 
+    #          |   | Locations |...| Locations | Times |...| Times | Locations |...| Locations | Times  |...| Times  |
+    #          |   | Rider     |   | Rider     | Rider |   | Rider | Driver    |   | Driver    | Driver |   | Driver |
+    #  --------|...|-----------|---|-----------|-------|---|-------|-----------|---|-----------|--------|---|--------|
+    #  Member 1|   |           |   |           |       |   |       |           |   |           |        |   |        |
+    #  Member 2|   |
+    #  .       |   |
+    #  .       |   |
+    #  .       |   |
+    #  Member n|   |
 
     # create a dict for each day
 


### PR DESCRIPTION
Added framework and support but let's hold off on doing much here until the pull request backlog is cleared up a bit. We can check the documentation and check compliance with Google style in preparation for sphinx autodoc.

`brew install sphinx-doc`
`pip install sphinx`


To build HTML locally:

`cd docs && make html`

Close #38 